### PR TITLE
Add support for Hyper terminal, closes #169

### DIFF
--- a/Vagrant Manager/AppDelegate.m
+++ b/Vagrant Manager/AppDelegate.m
@@ -639,11 +639,23 @@
              "else\n"
              "run script v2_script\n"
              "end\n", command, command];
+    }
+    else if ([terminalName isEqualToString:@"Hyper"]) {
+        s = [NSString stringWithFormat:
+             @"tell application \"Hyper\"\n"
+             "activate\n"
+             "delay 2\n"
+             "tell application \"System Events\"\n"
+             "keystroke \"%@\"\n"
+             "key code 36\n"
+             "end tell\n"
+             "end tell\n", command];
     } else {
         s = [NSString stringWithFormat:@"tell application \"Terminal\"\n"
              "activate\n"
              "do script \"%@\"\n"
              "end tell\n", command];
+        NSLog(@"Value of string is %@", s);
     }
     
     NSAppleScript *as = [[NSAppleScript alloc] initWithSource: s];

--- a/Vagrant Manager/PreferencesWindow.m
+++ b/Vagrant Manager/PreferencesWindow.m
@@ -48,6 +48,9 @@
     
     if ([terminalPreference isEqualToString:@"iTerm"]) {
         [self.terminalPreferencePopUpButton selectItemWithTag:101];
+    }
+    else if ([terminalPreference isEqualToString:@"Hyper"]) {
+        [self.terminalPreferencePopUpButton selectItemWithTag:102];
     } else {
         [self.terminalPreferencePopUpButton selectItemWithTag:100];
     }
@@ -150,6 +153,10 @@
     
     if (self.terminalPreferencePopUpButton.selectedItem.tag == 101) {
         terminalPreference = @"iTerm";
+    }
+    else if (self.terminalPreferencePopUpButton.selectedItem.tag == 102)
+    {
+        terminalPreference = @"Hyper";
     } else {
         terminalPreference = @"Terminal";
     }

--- a/Vagrant Manager/PreferencesWindow.xib
+++ b/Vagrant Manager/PreferencesWindow.xib
@@ -60,7 +60,7 @@
                                 <popUpButton verticalHuggingPriority="750" id="5JC-yq-pDl">
                                     <rect key="frame" x="191" y="640" width="211" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" title="Terminal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" tag="100" imageScaling="proportionallyDown" inset="2" selectedItem="kjx-me-UIj" id="m4I-I4-1Um">
+                                    <popUpButtonCell key="cell" type="push" title="iTerm/iTerm2" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="101" imageScaling="proportionallyDown" inset="2" selectedItem="nvj-E8-vFA" id="m4I-I4-1Um">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="Qfr-XM-GF3">

--- a/Vagrant Manager/PreferencesWindow.xib
+++ b/Vagrant Manager/PreferencesWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13196" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13196"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -60,13 +60,14 @@
                                 <popUpButton verticalHuggingPriority="750" id="5JC-yq-pDl">
                                     <rect key="frame" x="191" y="640" width="211" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" title="iTerm/iTerm2" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="101" imageScaling="proportionallyDown" inset="2" selectedItem="nvj-E8-vFA" id="m4I-I4-1Um">
+                                    <popUpButtonCell key="cell" type="push" title="Terminal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" tag="100" imageScaling="proportionallyDown" inset="2" selectedItem="kjx-me-UIj" id="m4I-I4-1Um">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="Qfr-XM-GF3">
                                             <items>
                                                 <menuItem title="Terminal" tag="100" id="kjx-me-UIj"/>
                                                 <menuItem title="iTerm/iTerm2" state="on" tag="101" id="nvj-E8-vFA"/>
+                                                <menuItem title="Hyper" tag="102" id="fdc-NL-UhO"/>
                                             </items>
                                         </menu>
                                     </popUpButtonCell>


### PR DESCRIPTION
Added support for Hyperterm. Use of AppleScript is a little hacky compared to the other terminal launch scripts, but unfortunately Hyper [doesn't support receiving text/work via AppleScript](https://github.com/zeit/hyper/issues/540).